### PR TITLE
Adds the _.flip function for flipping an arbitrary number of arguments.

### DIFF
--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -49,6 +49,12 @@ $(document).ready(function() {
     equal(_.flip2(div)(10,2), 0.2, 'should return a function that flips the first two args to a function');
   });
 
+  test("flip", function() {
+    var echo = function() { return Array.prototype.slice.call(arguments, 0); };
+
+    deepEqual(_.flip(echo)(1, 2, 3, 4), [4, 3, 2, 1], 'should return a function that flips the first three or more args to a function');
+  });
+
   test("fnull", function() {
     var a = [1,2,3,null,5];
     var b = [1,2,3,undefined,5];

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -15,6 +15,7 @@
 
   var existy = function(x) { return x != null; };
   var truthy = function(x) { return (x !== false) && existy(x); };
+  var __reverse = [].reverse;
   
   // Mixing in the combinator functions
   // ----------------------------------
@@ -148,6 +149,16 @@
         return fun.apply(null, arguments);
       };
     },
+
+    // Flips an arbitrary number of args of a function
+    flip: function(fun) {
+      return function(/* args */) {
+        var reversed = __reverse.call(arguments);
+
+        return fun.apply(null, reversed);
+      };
+    },
+    
     k: _.always,
     t: _.pipeline
   });


### PR DESCRIPTION
flip2 can now be defined from flip if necessary. Compatiblity: IE6+.

Limitation: _.flip does not establish the correct arity. Then again, neither does fnull, so this may not be an underscore-contrib standard contract.
