### PR TITLE
An implementation of unsplat that allows for prefacing arguments

### DIFF
--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -43,6 +43,24 @@ $(document).ready(function() {
     equal(notOdd(3), false, 'should return a function that is the opposite of the function given');
   });
 
+  test("unsplat", function() {
+    var echo  = _.unsplat(function (args) { return args; }),
+        echo2 = _.unsplat(function (first, rest) { return [first, rest]; }),
+        echo3 = _.unsplat(function (first, second, rest) { return [first, second, rest]; }),
+        undefined = void 0;
+
+    deepEqual(echo(), [], 'should return no arguments');
+    deepEqual(echo(1), [1], 'should return the arguments provded');
+    deepEqual(echo(1,2), [1,2], 'should return the arguments provded');
+    deepEqual(echo(1,2,3), [1,2,3], 'should return the arguments provded');
+
+    deepEqual(echo2(), [undefined, []], 'should return no arguments');
+    deepEqual(echo2(1), [1, []], 'should return the arguments provded');
+    deepEqual(echo2(1,2), [1,[2]], 'should return the arguments provded');
+    deepEqual(echo2(1,2,3), [1,[2,3]], 'should return the arguments provded');
+    deepEqual(echo2(1,2,3,4), [1,[2,3,4]], 'should return the arguments provded');
+  });
+
   test("flip2", function() {
     var div = function(n, d) { return n/d; };
 

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -16,6 +16,7 @@
   var existy = function(x) { return x != null; };
   var truthy = function(x) { return (x !== false) && existy(x); };
   var __reverse = [].reverse;
+  var __slice = [].slice;
   
   // Mixing in the combinator functions
   // ----------------------------------
@@ -102,9 +103,27 @@
     // a function that takes varargs and wraps all
     // in an array that is passed to the original function.
     unsplat: function(fun) {
-      return function() {
-        return fun.call(null, _.toArray(arguments));
-      };
+      var funLength = fun.length;
+
+      if (funLength < 1) {
+        return fun;
+      }
+      else if (funLength === 1)  {
+        return function () {
+          return fun.call(this, __slice.call(arguments, 0))
+        }
+      }
+      else {
+        return function () {
+          var numberOfArgs = arguments.length,
+              namedArgs = __slice.call(arguments, 0, funLength - 1),
+              numberOfMissingNamedArgs = Math.max(funLength - numberOfArgs - 1, 0),
+              argPadding = new Array(numberOfMissingNamedArgs),
+              variadicArgs = __slice.call(arguments, fun.length - 1);
+
+          return fun.apply(this, namedArgs.concat(argPadding).concat([variadicArgs]))
+        }
+      }
     },
 
     // Returns a function that returns an array of the calls to each


### PR DESCRIPTION
The original supported:

```
unsplat(function (args) { ... })
```

The revision supports that, plus:

```
unspat(function (first, args) { ... })
unspat(function (first, second, args) { ... })
unspat(function (first, second, third, args) { ... })
```

Very similarly to CoffeeScript's `(first, args...) -> ...` or Ruby's `def foo first, args*`
