### PR TITLE
Proposed: _.arity for forcing a function's arity

### DIFF
--- a/test/function.arity.js
+++ b/test/function.arity.js
@@ -14,4 +14,41 @@ $(document).ready(function() {
 
     equal(_.fix(parseInt, _, 10)('11'), 11, 'should "fix" common js foibles');
   });
+  
+  test("arity", function () {
+    function variadic () { return arguments.length; }
+    function unvariadic  (a, b, c) { return arguments.length; }
+  
+    equal( _.arity(unvariadic.length, variadic).length, unvariadic.length, "should set the length");
+    equal( _.arity(3, variadic)(1, 2, 3, 4, 5), unvariadic(1, 2, 3, 4, 5), "shouldn't trim arguments");   
+    equal( _.arity(3, variadic)(1), unvariadic(1), "shouldn't pad arguments");
+    
+    // this is the big use case for _.arity:
+  
+    function reverse (list) {
+      return [].reduce.call(list, function (acc, element) {
+        acc.unshift(element);
+        return acc;
+      }, []);
+    }
+    
+    function naiveFlip (fun) {
+      return function () {
+        return fun.apply(this, reverse(arguments));
+      }
+    }
+    
+    function echo (a, b, c) { return [a, b, c]; }
+    
+    deepEqual(naiveFlip(echo)(1, 2, 3), [3, 2, 1], "naive flip flips its arguments");
+    notEqual(naiveFlip(echo).length, echo.length, "naiveFlip gets its arity wrong");
+    
+    function flipWithArity (fun) {
+      return _.arity(fun.length, naiveFlip(fun));
+    }
+    
+    deepEqual(flipWithArity(echo)(1, 2, 3), [3, 2, 1], "flipWithArity flips its arguments");
+    equal(flipWithArity(echo).length, echo.length, "flipWithArity gets its arity correct");
+    
+  });
 });

--- a/underscore.function.arity.js
+++ b/underscore.function.arity.js
@@ -40,7 +40,51 @@
       f._original = fun;
 
       return f;
+    },
+
+    unary: function (fun) {
+      return function unary (a) {
+        return fun.call(this, a);
+      }
+    },
+
+    binary: function (fun) {
+      return function binary (a, b) {
+        return fun.call(this, a, b);
+      }
+    },
+
+    ternary: function (fun) {
+      return function ternary (a, b, c) {
+        return fun.call(this, a, b, c);
+      }
+    },
+
+    quaternary: function (fun) {
+      return function quaternary (a, b, c, d) {
+        return fun.call(this, a, b, c, d);
+      }
     }
+  
   });
+  
+  _.arity = (function () {
+    var FUNCTIONS = {};
+    return function arity (numberOfArgs, fun) {
+      if (FUNCTIONS[numberOfArgs] == null) {
+        var parameters = new Array(numberOfArgs);
+        for (var i = 0; i < numberOfArgs; ++i) {
+          parameters[i] = "__" + i;
+        }
+        var pstr = parameters.join();
+        var code = "return function ("+pstr+") { return fun.apply(this, arguments); };";
+        FUNCTIONS[numberOfArgs] = new Function(['fun'], code);
+      }
+      if (fun == null) {
+        return function (fun) { return arity(numberOfArgs, fun); };
+      }
+      else return FUNCTIONS[numberOfArgs](fun);
+    };
+  })();
 
 })(this);


### PR DESCRIPTION
The use case is writing combinators that respect the arity of the functions they decorate. e.g.

```
function reverse (list) {
  return [].reduce.call(list, function (acc, element) {
    acc.unshift(element);
    return acc;
  }, []);
}

function naiveFlip (fun) {
  return function () {
    return fun.apply(this, reverse(arguments));
  }
}

function echo (a, b, c) { return [a, b, c]; }

deepEqual(naiveFlip(echo)(1, 2, 3), [3, 2, 1], "naive flip flips its arguments");
notEqual(naiveFlip(echo).length, echo.length, "naiveFlip gets its arity wrong");

function flipWithArity (fun) {
  return _.arity(fun.length, naiveFlip(fun));
}

deepEqual(flipWithArity(echo)(1, 2, 3), [3, 2, 1], "flipWithArity flips its arguments");
equal(flipWithArity(echo).length, echo.length, "flipWithArity gets its arity correct");
```
