### PR TITLE
Add an entry point in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+['array.builders',
+ 'array.selectors',
+ 'function.arity',
+ 'function.combinators',
+ 'function.iterators',
+ 'function.predicates',
+ 'object.builders',
+ 'object.selectors',
+ 'util.existential',
+ 'util.strings',
+ 'util.trampolines'].forEach(function (lib) {
+   require('./underscore.'+lib);
+ });
+
+module.exports = require('underscore');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "underscore-contrib",
   "version": "0.0.1",
+  "main": "index.js",
   "dependencies": {
     "underscore": "*"
   },


### PR DESCRIPTION
This adds a file, `index.js`, which loads all of the mixins and exports
the modified underscore library. After setting the `main` property in
package.json to this index.js file, underscore with the contrib modules
mixed in can be included a project by doing:

`var _ = require('underscore-contrib');`

(Note, you will also have to publish the module to NPM before the above
will work.)

I made the assumption that for the node module "just mixin everything"
was a valid strategy. I'm happy to change it if that's not the case.
