### PR TITLE
Proposed: _.dictionary is the 'flip' of _.accessor

### DIFF
--- a/test/object.selectors.js
+++ b/test/object.selectors.js
@@ -10,6 +10,13 @@ $(document).ready(function() {
     deepEqual(_.map(a, _.accessor('a')), [1, undefined], 'should return a function that plucks');
   });
 
+  test("dictionary", function() {
+    var a = [{a: 1, b: 2}, {c: 3}];
+
+    equal(_.dictionary(a[0])('a'), 1, 'should return a function that acts as a dictionary');
+    equal(_.dictionary(a[1])('a'), undefined, 'should return a function that acts as a dictionary, or returns undefined');
+  });
+
   test("selectKeys", function() {
     deepEqual(_.selectKeys({'a': 1, 'b': 2}, ['a']), {'a': 1}, 'shold return a map of the desired keys');
     deepEqual(_.selectKeys({'a': 1, 'b': 2}, ['z']), {}, 'shold return an empty map if the desired keys are not present');

--- a/underscore.object.selectors.js
+++ b/underscore.object.selectors.js
@@ -27,6 +27,14 @@
         return (obj && obj[field]);
       };
     },
+    
+    // Given an object, returns a function that will attempt to look up a field
+    // that it's given.
+    dictionary: function (obj) {
+      return function(field) {
+        return (obj && field && obj[field]);
+      };
+    },
 
     // Like `_.pick` except that it takes an array of keys to pick.
     selectKeys: function (obj, ks) {


### PR DESCRIPTION
```
_.accessor('a')({a: 1, b: 2})
  //=> 1

_.dictionary({a: 1, b: 2})('a')
  //=> 1
```

In short, it turns any object into a dictionary function. Example use: Looking up the next state of a cellular automaton cell from its neighbour count.
