### PR TITLE
Juxt now supports functions w/ >1 argument

### DIFF
--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -114,9 +114,9 @@ $(document).ready(function() {
   });
 
   test("juxt", function() {
-    var run = _.juxt(function(s) { return s.length; }, parseInt, _.always(108));
+    var run = _.juxt(function(s, n) { return s.length + n; }, parseInt, _.always(108));
 
-    deepEqual(run('42'), [2, 42, 108], 'should return a function that returns an array of the originally supplied functions called');
+    deepEqual(run('42', 10), [12, 42, 108], 'should return a function that returns an array of the originally supplied functions called');
   });
 
   test("accessor", function() {

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -155,9 +155,10 @@
     juxt: function(/* funs */) {
       var funs = arguments;
 
-      return function(arg) {
+      return function(/* args */) {
+        var args = arguments;
         return _.map(funs, function(f) {
-          return f(arg);
+          return f.apply(null, args);
         });
       };
     },


### PR DESCRIPTION
Previously juxt was only forwarding a single argument to it's functions, now it forwards all arguments.
