### PR TITLE
getPath (aka deepGet)

### DIFF
--- a/test/object.selectors.js
+++ b/test/object.selectors.js
@@ -26,15 +26,14 @@ $(document).ready(function() {
     var deepObject = { a: { b: { c: "c" } }, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ["arr"] };
     var deepArr = [[["thirdLevel"]]];
 
-    equal(_.getPath(deepObject, ["a", "b", "c"]), "c", "should get a deep property's value from objects");
+    strictEqual(_.getPath(deepObject, ["a", "b", "c"]), "c", "should get a deep property's value from objects");
     strictEqual(_.getPath(deepArr, [0, 0, 0]), "thirdLevel", "should get a deep property's value from arrays");
     strictEqual(_.getPath(deepObject, ["arrayVal", 0]), "arr", "should get a deep property's value from nested arrays and objects");
 
-    equal(_.getPath(deepObject, ["undefinedVal"]), undefined, "should return undefined for undefined properties");
-    equal(_.getPath(deepObject, ["nullVal"]), undefined, "should return undefined for null properties");
-    equal(_.getPath(deepObject, ["a", "notHere"]), undefined, "should return undefined for non-existent properties");
-
-    equal(_.getPath(deepObject, ["undefinedVal"], "myDefault"), "myDefault", "should return a default value instead of undefined if one is provided");
+    strictEqual(_.getPath(deepObject, ["undefinedVal"]), undefined, "should return undefined for undefined properties");
+    strictEqual(_.getPath(deepObject, ["a", "notHere"]), undefined, "should return undefined for non-existent properties");
+    strictEqual(_.getPath(deepObject, ["nullVal"]), null, "should return null for null properties");
+    strictEqual(_.getPath(deepObject, ["nullVal", "notHere", "notHereEither"]), undefined, "should return undefined for non-existent descendents of null properties");
   });
 
 });

--- a/underscore.object.selectors.js
+++ b/underscore.object.selectors.js
@@ -43,17 +43,20 @@
 
     // Gets the value at any depth in a nested object based on the
     // path described by the keys given.
-    getPath: function getPath (obj, ks, defaultValue) {
-      // If we have reached an undefined/null property
-      // then stop executing and return the default value.
-      // If no default was provided it will be undefined.
-      if (obj == null) return defaultValue;
+    getPath: function getPath (obj, ks) {
+      // If we have reached an undefined property
+      // then stop executing and return undefined
+      if (obj === undefined) return;
 
       // If the path array has no more elements, we've reached
       // the intended property and return its value
       if (ks.length === 0) return obj;
 
-      return getPath(obj[[].shift.call(ks)], ks, defaultValue);
+      // If we still have elements in the path array and the current
+      // value is null, stop executing and return undefined
+      if (obj === null) return;
+
+      return getPath(obj[[].shift.call(ks)], ks);
     }
   });
 


### PR DESCRIPTION
I've implemented a deep property getter based on my original proposal in #28.

Some differences with this version:
- I renamed it `getPath` to match `updatePath` and `setPath`.
- It only accepts an array of keys as the selector, not a string with dot notation. This is also to match `updatePath` and `setPath`.

@michaelficarra had noted some similarities between #28 and https://github.com/documentcloud/underscore/pull/1106. With the changes mentioned above, there is less overlap in the proposals.

I've attempted to follow the existing code and testing style, but let me know if something needs to be changed.
