### PR TITLE
Removal of curry2 and curry2flipped

### DIFF
--- a/test/function.arity.js
+++ b/test/function.arity.js
@@ -52,16 +52,6 @@ $(document).ready(function() {
     
   });
   
-  test("curry2", function () {
-    
-    function echo () { return [].slice.call(arguments, 0); }
-    
-    deepEqual(echo(1, 2), [1, 2], "Control test");
-    deepEqual(_.curry2(echo)(1, 2), [1, 2], "Accepts arguments greedily");
-    deepEqual(_.curry2(echo)(1)(2), [1, 2], "Accepts curried arguments");
-    
-  });
-
   test("curry", function() {
     var func = function (x, y, z) {
         return x + y + z;

--- a/underscore.function.arity.js
+++ b/underscore.function.arity.js
@@ -98,30 +98,6 @@
       };
     },
     
-    // greedy currying for functions taking two arguments.
-    curry2: function (fun) {
-      return function curried (first, optionalLast) {
-        if (arguments.length === 1) {
-          return function (last) {
-            return fun(first, last);
-          };
-        }
-        else return fun(first, optionalLast);
-      };
-    },
-    
-    // greedy flipped currying for functions taking two arguments.
-    curry2flipped: function (fun) {
-      return function curried (last, optionalFirst) {
-        if (arguments.length === 1) {
-          return function (first) {
-            return fun(first, last);
-          };
-        }
-        else return fun(optionalFirst, last);
-      };
-    },
-    
     // Flexible curry function with strict arity.
     // Argument application left to right.
     // source: https://github.com/eborden/js-curry


### PR DESCRIPTION
These methods become redundant with the introduction of curry and rCurry.
