### PR TITLE
Don't use variable inside of require in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
-['array.builders',
- 'array.selectors',
- 'collections.walk',
- 'function.arity',
- 'function.combinators',
- 'function.iterators',
- 'function.predicates',
- 'object.builders',
- 'object.selectors',
- 'util.existential',
- 'util.strings',
- 'util.trampolines'].forEach(function (lib) {
-   require('./underscore.'+lib);
- });
+require('./underscore.array.builders');
+require('./underscore.array.selectors');
+require('./underscore.collections.walk');
+require('./underscore.function.arity');
+require('./underscore.function.combinators');
+require('./underscore.function.iterators');
+require('./underscore.function.predicates');
+require('./underscore.object.builders');
+require('./underscore.object.selectors');
+require('./underscore.util.existential');
+require('./underscore.util.strings');
+require('./underscore.util.trampolines');
 
 module.exports = require('underscore');


### PR DESCRIPTION
Backstory: I tried bundling code which uses underscore-contrib for browsers with browserify. It complained about not being able to find 'underscore.array.builders'. The reason lies in the way modules are being required in contrib's `index.js`: `require('underscore.'+lib)`. browserify only recognizes constant values passed to `require`, e.g., `require('underscore.array.builders')`.

Stylistically I prefer the current solution but I feel it's more important to have statically named dependencies so compilers & bundlers can recognise and work with them.
