### PR TITLE
Make _.getPath and _.hasPath not consume `ks` argument

### DIFF
--- a/test/object.selectors.js
+++ b/test/object.selectors.js
@@ -30,8 +30,10 @@ $(document).ready(function() {
   test("getPath", function() {
     var deepObject = { a: { b: { c: "c" } }, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ["arr"] };
     var deepArr = [[["thirdLevel"]]];
+    var ks = ["a", "b", "c"];
 
-    strictEqual(_.getPath(deepObject, ["a", "b", "c"]), "c", "should get a deep property's value from objects");
+    strictEqual(_.getPath(deepObject, ks), "c", "should get a deep property's value from objects");
+    deepEqual(ks, ["a", "b", "c"], "should not have mutated ks argument");
     strictEqual(_.getPath(deepArr, [0, 0, 0]), "thirdLevel", "should get a deep property's value from arrays");
     strictEqual(_.getPath(deepObject, ["arrayVal", 0]), "arr", "should get a deep property's value from nested arrays and objects");
 
@@ -43,9 +45,11 @@ $(document).ready(function() {
 
   test("hasPath", function() {
     var deepObject = { a: { b: { c: "c" } }, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ["arr"] };
+    var ks = ["a", "b", "c"];
 
     strictEqual(_.hasPath(deepObject, ["notHere", "notHereEither"]), false, "should return false if the path doesn't exist");
-    strictEqual(_.hasPath(deepObject, ["a", "b", "c"]), true, "should return true if the path exists");
+    strictEqual(_.hasPath(deepObject, ks), true, "should return true if the path exists");
+    deepEqual(ks, ["a", "b", "c"], "should not have mutated ks argument");
 
     strictEqual(_.hasPath(deepObject, ["arrayVal", 0]), true, "should return true for an array's index if it is defined");
     strictEqual(_.hasPath(deepObject, ["arrayVal", 999]), false, "should return false for an array's index if it is not defined");

--- a/underscore.object.selectors.js
+++ b/underscore.object.selectors.js
@@ -65,7 +65,7 @@
       // value is null, stop executing and return undefined
       if (obj === null) return void 0;
 
-      return getPath(obj[[].shift.call(ks)], ks);
+      return getPath(obj[_.first(ks)], _.rest(ks));
     },
 
     // Returns a boolean indicating whether there is a property
@@ -79,7 +79,7 @@
 
       if (numKeys === 1) return true;
 
-      return hasPath(obj[[].shift.call(ks)], ks);
+      return hasPath(obj[_.first(ks)], _.rest(ks));
     }
   });
 


### PR DESCRIPTION
When using a partially applied `_.getPath` I noticed it only acted upon the first element in the list. The reason is that it consumes the `ks` argument. I presume `_.getPath` and `_.hasPath` are not supposed to consume any of their arguments.

`shift` [mutates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), so I've replaced the shift call with `_.first` and `_.rest` calls.

I've also added a test which asserts that `ks` isn't mutated.

Edit: Of course, if this is by design, please consume this pull request by closing it.
