### PR TITLE
Fixed module declaration typo in operators tests.

### DIFF
--- a/test/util.operators.js
+++ b/test/util.operators.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 
-  module("underscore.util.existential");
+  module("underscore.util.operators");
 
   test("add", function() {
     equal(_.add(1, 1), 2, '1 + 1 = 2');


### PR DESCRIPTION
Small thing.

Cheers!
