### PR TITLE
function.predicates - adding isPlainObject

### DIFF
--- a/test/function.predicates.js
+++ b/test/function.predicates.js
@@ -61,6 +61,27 @@ $(document).ready(function() {
     equal(_.isSequential(true), false, 'should identify when something is not sequential');
   });
 
+  test("isPlainObject", function() {
+    equal(_.isPlainObject({}), true, 'should identify empty objects');
+    equal(_.isPlainObject({a: 1, b: 2}), true, 'should identify objects');
+    equal(_.isPlainObject(Object.create(null)), true, 'should identify objects with no prototype');
+    equal(_.isPlainObject(new (function() {})), true, 'should identify an instance as a plain object');
+
+    equal(_.isPlainObject([]), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(function(){}), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(null), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(1), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(0), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(-1), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(3.14), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject('undefined'), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(''), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(NaN), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(Infinity), false, 'should identify when something is not a plain object');
+    equal(_.isPlainObject(true), false, 'should identify when something is not a plain object');
+  });
+
+
   test("isEven", function() {
     equal(_.isEven(0), true, 'should identify even numbers');
     equal(_.isEven(2), true, 'should identify even numbers');

--- a/underscore.function.predicates.js
+++ b/underscore.function.predicates.js
@@ -35,6 +35,9 @@
     // A seq is something considered a sequential composite type (i.e. arrays and `arguments`).
     isSequential: function(x) { return (_.isArray(x)) || (_.isArguments(x)); },
 
+    // Check if an object is an object literal, since _.isObject(function() {}) === _.isObject([]) === true
+    isPlainObject: function(x) { return (_.isObject(x) && !_.isFunction(x) && !_.isArray(x)); },
+
     // These do what you think that they do
     isZero: function(x) { return 0 === x; },
     isEven: function(x) { return _.isFinite(x) && (x & 1) === 0; },


### PR DESCRIPTION
Simple, but useful, checks if an object is actually a `{}` object and not a function or array.

Related discussion in https://github.com/jashkenas/underscore/issues/580.
