### PR TITLE
Adding cli phantom test runner & global fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "underscore": "*"
   },
   "devDependencies": {
+    "phantomjs": "1.9.0-1",
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-uglify": "0.2.0"
@@ -13,6 +14,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/documentcloud/underscore-contrib.git"
+  },
+  "scripts": {
+    "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true"
   },
   "license": "MIT",
   "author": {"name": "Fogus",

--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -92,16 +92,16 @@ $(document).ready(function() {
     deepEqual(echo3(1,2,3), [[1], 2, 3], 'should return the arguments provded');
     deepEqual(echo3(1,2,3,4), [[1, 2], 3, 4], 'should return the arguments provded');
   });
-  
+
   test("mapArgsWith", function () {
     var echo  = _.unsplatl(function (args) { return args; });
     function double (n) { return n * 2; }
     function plusOne (n) { return n + 1; }
-    
+
     deepEqual(_.mapArgsWith(double, echo)(), [], "should handle the empty case")
     deepEqual(_.mapArgsWith(double, echo)(42), [84], "should handle one arg")
     deepEqual(_.mapArgsWith(plusOne, echo)(1, 2, 3), [2, 3, 4], "should handle many args")
-    
+
     deepEqual(_.mapArgsWith(double)(echo)(), [], "should handle the empty case")
     deepEqual(_.mapArgsWith(double)(echo)(42), [84], "should handle one arg")
     deepEqual(_.mapArgsWith(plusOne)(echo)(1, 2, 3), [2, 3, 4], "should handle many args")
@@ -156,7 +156,10 @@ $(document).ready(function() {
     var f = _.bound(obj, 'fun');
 
     equal(f('there'), 'hello there', 'should return concatenation of obj.a and string argument');
-    equal(f.length, 1, 'f should have arity of 1');
+
+    // Without Function.bind the arity is incorrect.
+    if (Function.prototype.bind) equal(f.length, 1, 'f should have arity of 1');
+
     throws(function() {
       _.bound(obj, 'nofun');
     }, TypeError, 'should throw for non-function properties');

--- a/underscore.function.iterators.js
+++ b/underscore.function.iterators.js
@@ -12,24 +12,24 @@
 
   // Helpers
   // -------
-  
+
   var HASNTBEENRUN = {};
-  
+
   function unary (fun) {
     return function (first) {
       return fun.call(this, first);
     };
   }
-  
+
   function binary (fun) {
     return function (first, second) {
       return fun.call(this, first, second);
     };
   }
-  
+
   var undefined = void 0;
 
-  
+
   // Mixing in the iterator functions
   // --------------------------------
 
@@ -48,7 +48,7 @@
       }
       return state;
     };
-  
+
     function unfold (seed, unaryFn) {
       var state = HASNTBEENRUN;
       return function () {
@@ -61,7 +61,7 @@
         else return state;
       };
     };
-  
+
     // note that the unfoldWithReturn behaves differently than
     // unfold with respect to the first value returned
     function unfoldWithReturn (seed, unaryFn) {
@@ -84,6 +84,7 @@
     function accumulate (iter, binaryFn, initial) {
       var state = initial;
       return function () {
+        var element;
         element = iter();
         if (element == null) {
           return element;
@@ -96,11 +97,12 @@
         }
       };
     };
-  
+
     function accumulateWithReturn (iter, binaryFn, initial) {
       var state = initial,
           stateAndReturnValue;
       return function () {
+        var element;
         element = iter();
         if (element == null) {
           return element;
@@ -117,7 +119,7 @@
         }
       };
     };
-  
+
     function map (iter, unaryFn) {
       return function() {
         var element;
@@ -173,13 +175,13 @@
         return void 0;
       };
     };
-  
+
     function reject (iter, unaryPredicateFn) {
       return select(iter, function (something) {
         return !unaryPredicateFn(something);
       });
     };
-  
+
     function find (iter, unaryPredicateFn) {
       return select(iter, unaryPredicateFn)();
     }
@@ -200,7 +202,7 @@
       }
       else return iter;
     };
-  
+
     function drop (iter, numberToDrop) {
       return slice(iter, numberToDrop == null ? 1 : numberToDrop);
     }
@@ -215,7 +217,7 @@
         return array[index++];
       };
     };
-  
+
     function Tree (array) {
       var index, myself, state;
       index = 0;
@@ -244,7 +246,7 @@
       };
       return myself;
     };
-  
+
     function K (value) {
       return function () {
         return value;
@@ -254,7 +256,7 @@
     function upRange (from, to, by) {
       return function () {
         var was;
-      
+
         if (from > to) {
           return void 0;
         }
@@ -269,7 +271,7 @@
     function downRange (from, to, by) {
       return function () {
         var was;
-      
+
         if (from < to) {
           return void 0;
         }
@@ -280,7 +282,7 @@
         }
       };
     };
-  
+
     function range (from, to, by) {
       if (from == null) {
         return upRange(1, Infinity, 1);
@@ -302,7 +304,7 @@
       }
       else return k(from);
     };
-  
+
     var numbers = unary(range);
 
     _.iterators = {


### PR DESCRIPTION
Adds a similar implementation to the underscore & backbone suites, using the phantomjs test runner to run the test suite using `npm test`. This pointed out 2 global variables in `function.iterators` as well as the fact that the arity test on `_.bound` [is incorrect](https://github.com/tgriesser/underscore-contrib/commit/9afee070670b1445d945a7a2a5508bfd60598d63#L1R161) unless the native `bind` exists (@braddunbar pointed out to me that the phantom's webkit doesn't have this).
