### PR TITLE
improve consistency in existence functions

### DIFF
--- a/underscore.util.existential.js
+++ b/underscore.util.existential.js
@@ -13,19 +13,20 @@
   // Helpers
   // -------
 
-  
+
   // Mixing in the truthiness
   // ------------------------
 
   _.mixin({
-    exists: function(x) { return x != null; },
+    exists: function(x) { return typeof x !== "undefined" && x !== null; },
     truthy: function(x) { return (x !== false) && _.exists(x); },
     falsey: function(x) { return !_.truthy(x); },
     not:    function(b) { return !b; },
     firstExisting: function() {
         for (var i = 0; i < arguments.length; i++) {
-            if (arguments[i] != null) return arguments[i];
+            if (_.exists(arguments[i])) return arguments[i];
         }
+        return undefined;
     }
   });
 


### PR DESCRIPTION
This commit does 3 small things:

1) Switch exists() to using === equality because:
  (a) Always using === is becoming a standard best practice, per Javascript: The Good Parts, etc. This implemetation exactly matches that used by CoffeeScript for it's existence operator.
  (b) It's internally more consistent, comparing truthy()

2) Switch firstExisting() to using exits() instead of re-implementing it, because this is functional programming, and it's called firstExisting, not firstNonNull.

3) Make it explicit that firstExisting will return undefined if no existing argument is found. This is more for readability, but may also protect against possible cross-browser bugs or compiler bugs.
