### PR TITLE
Enhance getPath & hasPath with support for dot notation

### DIFF
--- a/test/object.selectors.js
+++ b/test/object.selectors.js
@@ -41,6 +41,8 @@ $(document).ready(function() {
     strictEqual(_.getPath(deepObject, ["a", "notHere"]), undefined, "should return undefined for non-existent properties");
     strictEqual(_.getPath(deepObject, ["nullVal"]), null, "should return null for null properties");
     strictEqual(_.getPath(deepObject, ["nullVal", "notHere", "notHereEither"]), undefined, "should return undefined for non-existent descendents of null properties");
+
+    strictEqual(_.getPath(deepObject, "a.b.c"), "c", "should work with keys written in dot notation");
   });
 
   test("hasPath", function() {
@@ -59,6 +61,8 @@ $(document).ready(function() {
 
     strictEqual(_.hasPath(deepObject, ["nullVal", "notHere"]), false, "should return false for descendants of null properties");
     strictEqual(_.hasPath(deepObject, ["undefinedVal", "notHere"]), false, "should return false for descendants of undefined properties");
+
+    strictEqual(_.hasPath(deepObject, "a.b.c"), true, "should work with keys written in dot notation.");
   });
 
   test("pickWhen", function() {

--- a/underscore.object.selectors.js
+++ b/underscore.object.selectors.js
@@ -53,8 +53,11 @@
     },
 
     // Gets the value at any depth in a nested object based on the
-    // path described by the keys given.
+    // path described by the keys given. Keys may be given as an array
+    // or as a dot-separated string.
     getPath: function getPath (obj, ks) {
+      if (typeof ks == "string") ks = ks.split(".");
+
       // If we have reached an undefined property
       // then stop executing and return undefined
       if (obj === undefined) return void 0;
@@ -73,6 +76,8 @@
     // Returns a boolean indicating whether there is a property
     // at the path described by the keys given
     hasPath: function hasPath (obj, ks) {
+      if (typeof ks == "string") ks = ks.split(".");
+
       var numKeys = ks.length;
 
       if (obj == null && numKeys > 0) return false;


### PR DESCRIPTION
This enhancement allows for a more natural syntax when specifying the path to traverse. For example:

``` javascript
// Using an array for the path
_.getPath(obj, ["a", "b", "c"]);

// Using dot notation
_.getPath(obj, "a.b.c");
```

I've been using `getPath` fairly regularly lately, and I think dot notation would make it quite a bit nicer.
