### PR TITLE
Fixed broken test for _.splitWith

### DIFF
--- a/test/array.selectors.js
+++ b/test/array.selectors.js
@@ -40,9 +40,9 @@ $(document).ready(function() {
     var lessEq3p = function(n) { return n <= 3; };
     var lessEq3p$ = function(n) { return (n <= 3) ? true : null; };
 
-    deepEqual(_.splitWith(lessEq3p, a), [[1,2,3], [4,5]], 'should split an array when a function goes false');
-    deepEqual(_.splitWith(lessEq3p$, a), [[1,2,3], [4,5]], 'should split an array when a function goes false');
-    deepEqual(_.splitWith(lessEq3p$, []), [[],[]], 'should split an empty array into two empty arrays');
+    deepEqual(_.splitWith(a, lessEq3p), [[1,2,3], [4,5]], 'should split an array when a function goes false');
+    deepEqual(_.splitWith(a, lessEq3p$), [[1,2,3], [4,5]], 'should split an array when a function goes false');
+    deepEqual(_.splitWith([], lessEq3p$), [[],[]], 'should split an empty array into two empty arrays');
   });
 
   test("partitionBy", function() {


### PR DESCRIPTION
These assertions were throwing `typeError`s because the order of the arguments were reversed. 
