### PR TITLE
More robust `dist` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,9 @@ module.exports = function(grunt) {
     },
 
     qunit: {
-      all: ['test/index.html']
+      main: ['test/index.html'],
+      concat: ['test/dist-concat.html'],
+      min: ['test/dist-min.html']
     },
 
     jshint: {
@@ -73,8 +75,8 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask("test", ["jshint", "qunit"]);
+  grunt.registerTask("test", ["jshint", "qunit:main"]);
   grunt.registerTask("dist", ["concat", "uglify"]);
   grunt.registerTask('default', ['test']);
-  grunt.registerTask('dist', ['concat', 'uglify']);
+  grunt.registerTask('dist', ['test', 'concat', 'qunit:concat', 'uglify', 'qunit:min']);
 };

--- a/test/dist-concat.html
+++ b/test/dist-concat.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Underscore-contrib Test Suite</title>
+  <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen">
+  <script src="vendor/jquery.js"></script>
+  <script src="vendor/qunit.js"></script>
+  <script src="vendor/jslitmus.js"></script>
+  <script src="vendor/underscore.js"></script>
+
+  <!-- contrib libraries -->
+  <script src="../dist/underscore-contrib.js"></script>
+
+  <!-- contrib tests -->
+  <script src="array.builders.js"></script>
+  <script src="array.selectors.js"></script>
+  <script src="collections.walk.js"></script>
+  <script src="function.arity.js"></script>
+  <script src="function.combinators.js"></script>
+  <script src="function.dispatch.js"></script>
+  <script src="function.predicates.js"></script>
+  <script src="function.iterators.js"></script>
+  <script src="object.builders.js"></script>
+  <script src="object.selectors.js"></script>
+  <script src="util.existential.js"></script>
+  <script src="util.trampolines.js"></script>
+  <script src="util.operators.js"></script>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture">
+    <div id="map-test">
+      <div id="id1"></div>
+      <div id="id2"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/test/dist-min.html
+++ b/test/dist-min.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Underscore-contrib Test Suite</title>
+  <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen">
+  <script src="vendor/jquery.js"></script>
+  <script src="vendor/qunit.js"></script>
+  <script src="vendor/jslitmus.js"></script>
+  <script src="vendor/underscore.js"></script>
+
+  <!-- contrib libraries -->
+  <script src="../dist/underscore-contrib.min.js"></script>
+
+  <!-- contrib tests -->
+  <script src="array.builders.js"></script>
+  <script src="array.selectors.js"></script>
+  <script src="collections.walk.js"></script>
+  <script src="function.arity.js"></script>
+  <script src="function.combinators.js"></script>
+  <script src="function.dispatch.js"></script>
+  <script src="function.predicates.js"></script>
+  <script src="function.iterators.js"></script>
+  <script src="object.builders.js"></script>
+  <script src="object.selectors.js"></script>
+  <script src="util.existential.js"></script>
+  <script src="util.trampolines.js"></script>
+  <script src="util.operators.js"></script>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture">
+    <div id="map-test">
+      <div id="id1"></div>
+      <div id="id2"></div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Now the `dist` task will lint and test before concatenation and minification. In addition, it will rerun the tests over the concatenated and minified files to catch any (unlikely, but possible) issues introduced by those steps.
