### PR TITLE
Uncomment tests for custom walkers, and fix the failures.

### DIFF
--- a/test/collections.walk.js
+++ b/test/collections.walk.js
@@ -204,13 +204,13 @@ $(document).ready(function() {
     var visitor = function(node) {
       if (!_.isObject(node)) throw Error("Leaf value visited when it shouldn't be");
     };
-    equal(walker.pluck(tree, 'val').length, 7, 'pluck with custom traversal');/*
+    equal(walker.pluck(tree, 'val').length, 7, 'pluck with custom traversal');
     equal(walker.pluckRec(tree, 'val').length, 7, 'pluckRec with custom traversal');
 
     equal(walker.map(tree, _.walk.postorder, _.identity).length, 7, 'traversal strategy is dynamically scoped');
 
     // Check that the default walker is unaffected.
     equal(_.walk.map(tree, _.walk.postorder, _.identity).length, 14, 'default map still works');
-    equal(_.walk.pluckRec(tree, 'val').join(''), '0123456', 'default pluckRec still works');*/
+    equal(_.walk.pluckRec(tree, 'val').join(''), '0123456', 'default pluckRec still works');
   });
 });

--- a/underscore.collections.walk.js
+++ b/underscore.collections.walk.js
@@ -99,9 +99,9 @@
     filter: function(obj, strategy, visitor, context) {
       var results = [];
       if (obj == null) return results;
-      strategy.call(this, obj, function(value, key, parent) {
+      strategy(obj, function(value, key, parent) {
         if (visitor.call(context, value, key, parent)) results.push(value);
-      });
+      }, null, this._traversalStrategy);
       return results;
     },
 
@@ -119,9 +119,9 @@
     // `postorder`.
     map: function(obj, strategy, visitor, context) {
       var results = [];
-      strategy.call(this, obj, function(value, key, parent) {
+      strategy(obj, function(value, key, parent) {
         results[results.length] = visitor.call(context, value, key, parent);
-      });
+      }, null, this._traversalStrategy);
       return results;
     },
 
@@ -140,14 +140,20 @@
 
     // Recursively traverses `obj` in a depth-first fashion, invoking the
     // `visitor` function for each object only after traversing its children.
-    postorder: function(obj, visitor, context) {
-      walkImpl(obj, this._traversalStrategy, null, visitor, context);
+    // `traversalStrategy` is intended for internal callers, and is not part
+    // of the public API.
+    postorder: function(obj, visitor, context, traversalStrategy) {
+      traversalStrategy = traversalStrategy || this._traversalStrategy;
+      walkImpl(obj, traversalStrategy, null, visitor, context);
     },
 
     // Recursively traverses `obj` in a depth-first fashion, invoking the
     // `visitor` function for each object before traversing its children.
-    preorder: function(obj, visitor, context) {
-      walkImpl(obj, this._traversalStrategy, visitor, null, context);
+    // `traversalStrategy` is intended for internal callers, and is not part
+    // of the public API.
+    preorder: function(obj, visitor, context, traversalStrategy) {
+      traversalStrategy = traversalStrategy || this._traversalStrategy;
+      walkImpl(obj, traversalStrategy, visitor, null, context);
     },
 
     // Builds up a single value by doing a post-order traversal of `obj` and


### PR DESCRIPTION
Some of the tests for custom walkers were accidentally commented out,
masking some issues with the implementation. The problem was that after a
function has been bound using Function.bind(), its 'this' parameter cannot
be re-bound using 'Function.call'.

Thanks to @joshuacc for noticing, I'm not sure what happened.
