### PR TITLE
Added _.reverseOrder

### DIFF
--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -184,4 +184,17 @@ $(document).ready(function() {
     deepEqual(_.keepIndexed(b, posy), [2,4,5], 'keeps elements whose index passes a truthy test');
     deepEqual(_.keepIndexed(_.range(10), oddy), [1,3,5,7,9], 'keeps elements whose index passes a truthy test');
   });
+
+  test('reverseOrder', function() {
+    var arr = [1, 2, 3];
+
+    deepEqual(_.reverseOrder(arr), [3, 2, 1], 'returns an array whose elements are in the opposite order of the argument');
+    deepEqual(arr, [1, 2, 3], 'should not mutate the argument');
+
+    var throwingFn = function() { _.reverseOrder('string'); };
+    throws(throwingFn, TypeError, 'throws a TypeError when given a string');
+
+    var argObj = (function() { return arguments; })(1, 2, 3);
+    deepEqual(_.reverseOrder(argObj), [3, 2, 1], 'works with other array-like objects');
+  });
 });

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -178,6 +178,18 @@
         return pred(i, array[i]);
       }),
       existy);
+    },
+
+    // Accepts an array-like object (other than strings) as an argument and
+    // returns an array whose elements are in the reverse order. Unlike the
+    // built-in `Array.prototype.reverse` method, this does not mutate the
+    // original object. Note: attempting to use this method on a string will
+    // result in a `TypeError`, as it cannot properly reverse unicode strings.
+
+    reverseOrder: function(obj) {
+      if (typeof obj == 'string')
+        throw new TypeError('Strings cannot be reversed by _.reverseOrder');
+      return slice.call(obj).reverse();
     }
   });
 


### PR DESCRIPTION
This is a non-mutating version of `Array.prototype.reverse`. It is named differently so that people won't be confused by the fact that when using Underscore's chaining syntax, `reverse` is a mutating method. I went back and forth on the name a little bit, but this is the best I could come up with. Just let me know if you have a better idea.

It will throw a `TypeError` if you try to use it on a string, because it can't properly handle reversing unicode character sequences. See [Esrever](https://github.com/mathiasbynens/esrever) for more details.
