### PR TITLE
New functions: _.functionalize & _.methodize rotate `this` in and out of args

### DIFF
--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -158,4 +158,30 @@ $(document).ready(function() {
       _.bound(obj, 'nofun');
     }, TypeError, 'should throw for non-function properties');
   });
+
+  test("functionalize", function() {
+    var rect = {
+      x: 2,
+      y: 3,
+      area: function() {return this.x * this.y;},
+      extrude: function(z) {return _.merge(this, {z: z});}
+    };
+    var areaFunc = _.functionalize(rect.area),
+        extrudeFunc = _.functionalize(rect.extrude);
+    equal(areaFunc(rect), 6, "returned function's first arg becomes original method's `this`");
+    equal(extrudeFunc(rect, 4).z, 4, "all arguments are passed along");
+  });
+
+  test("methodize", function() {
+    function area(rect) {return rect.x * rect.y;}
+    function extrude(rect, z) {return _.merge(rect, {z: z});}
+    var rect = {
+      x: 2,
+      y: 3,
+      area: _.methodize(area),
+      extrude: _.methodize(extrude)
+    };
+    equal(rect.area(), 6, "returned method passes its receiver (`this`) as first arg to original function");
+    equal(rect.extrude(4).z, 4, "all arguments are passed along");
+  });
 });

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -227,6 +227,26 @@
         return fun.apply(null, reversed);
       };
     },
+
+    // Takes a method-style function (one which uses `this`) and pushes
+    // `this` into the argument list. The returned function uses its first
+    // argument as the receiver/context of the original function, and the rest
+    // of the arguments are used as the original's entire argument list.
+    functionalize: function(method) {
+      return function(ctx /*, args */) {
+        return method.apply(ctx, _.rest(arguments));
+      };
+    },
+
+    // Takes a function and pulls the first argument out of the argument
+    // list and into `this` position. The returned function calls the original
+    // with its receiver (`this`) prepending the argument list. The original
+    // is called with a receiver of `null`.
+    methodize: function(func) {
+      return function(/* args */) {
+        return func.apply(null, _.cons(this, arguments));
+      };
+    },
     
     k: _.always,
     t: _.pipeline


### PR DESCRIPTION
The purpose of these functions is to help a little in bridging the gap between the worlds of functional and OO.

`_.functionalize` takes a "method-style" function (one which uses `this`) and returns a new function which uses only its argument list. The first argument of the returned function gets used as the receiver (`this`) of the original function.

`_.methodize` is the inverse operation, taking an arguments-oriented function which doesn't rely on `this` and returning a function which is suitable for use as an object method (where `this` is passed as the first argument to the original function).

Both of these functions can be understood as rotating `this` in and out of the argument list (from the left-hand side).
