### PR TITLE
A Couple New Array Selector Methods

### DIFF
--- a/test/array.selectors.js
+++ b/test/array.selectors.js
@@ -86,6 +86,10 @@ $(document).ready(function() {
     deepEqual(_.nths(a,[1,5,3]), ['b', undefined, 'd'], 'should return undefined if out of bounds');
   });
 
+  test("valuesAt", function() {
+    equal(_.valuesAt, _.nths, 'valuesAt should be alias for nths');
+  });
+
   test("binPick", function() {
     var a = ['a','b','c', 'd'];
 

--- a/underscore.array.selectors.js
+++ b/underscore.array.selectors.js
@@ -47,7 +47,7 @@
     },
 
     // A function to get values via indices into an array
-    nths: function nths(array, indices) {
+    nths: nths = function(array, indices) {
       if (array == null) return void 0;
 
       if (isSeq(indices))
@@ -55,6 +55,7 @@
       else
         return nths(array, slice.call(arguments, 1));
     },
+    valuesAt: nths,
 
     // A function to get at "truthily" indexed values
     // bin refers to "binary" nature of true/false values in binIndices


### PR DESCRIPTION
I found them useful in streamlining some of my code.

"nths" corresponds roughly to ruby's "values_at" method.  You can pass in multiple indices, or an array of indices to return a selection: 

``` javascript
_.nths(['a', 'b', 'c'], 0,3,4) == _.nths(['a', 'b', 'c'], [0,3,4]) == ['a', 'c', undefined]
```

"binPick" allows indexing via a binary array: 

``` javascript
_.binPick(['a', 'b', 'c'], true, false, true, true) == _.binPick(['a', 'b', 'c'], [1,0,'yes', 'truthy']) == ['a', 'c', undefined]
```

Let me know if you find them useful and/or want me to write up some documentation. 

Also, I'm not crazy about the names, so feel free to suggest alternatives.  Thanks!
