### PR TITLE
Pass property key as iterator to _.uniq

### DIFF
--- a/test/vendor/underscore.js
+++ b/test/vendor/underscore.js
@@ -446,6 +446,9 @@
   // been sorted, you have the option of using a faster algorithm.
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iterator, context) {
+    if (_.isString(isSorted)) {
+      isSorted = _.property(isSorted);
+    }
     if (_.isFunction(isSorted)) {
       context = iterator;
       iterator = isSorted;


### PR DESCRIPTION
Allow `uniq` to follow `sortBy`, `groupBy` etc’s API in allowing iteration by string as well as function.
