### PR TITLE
Added initial bower.json file using existing tag structure

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "tests"
   ],
   "dependencies"  : {
-    "underscore"  : ">=1.5.0"
+    "underscore"  : ">=1.6.0"
   }
 }


### PR DESCRIPTION
Refs: https://github.com/documentcloud/underscore-contrib/pull/31

This is a basic bower.json file to get Bower in line with more recent versions of the repo. Underscore now has a bower file https://github.com/jashkenas/underscore/blob/master/bower.json

Right now Bower only picks up 2.0 because of the tagging structure.
