### PR TITLE
Fix example code in document

### DIFF
--- a/docs/underscore.object.selectors.js.md
+++ b/docs/underscore.object.selectors.js.md
@@ -35,7 +35,7 @@ var generals = {
 
 var getGeneralOf = _.dictionary(generals);
 
-_.getGeneralOf("rome");
+getGeneralOf("rome");
 // => "Scipio"
 ```
 


### PR DESCRIPTION
The `getGeneralOf` is assigned in local variable.
Not in `_` variable.
