### PR TITLE
Support conjoin and disjoin methods for single elements

### DIFF
--- a/test/function.combinators.js
+++ b/test/function.combinators.js
@@ -18,6 +18,8 @@ $(document).ready(function() {
   test("conjoin", function() {
     var isPositiveEven = _.conjoin(function(x) { return x > 0; }, function(x) { return (x & 1) === 0; });
 
+    equal(isPositiveEven(2), true, 'should recognize that element satisfies a conjunction');
+    equal(isPositiveEven(1), false, 'should recognize that element does not satisfy a conjunction');
     equal(isPositiveEven([2,4,6,8]), true, 'should recognize when all elements satisfy a conjunction');
     equal(isPositiveEven([2,4,6,7,8]), false, 'should recognize when an element fails to satisfy a conjunction');
   });
@@ -25,6 +27,8 @@ $(document).ready(function() {
   test("disjoin", function() {
     var orPositiveEven = _.disjoin(function(x) { return x > 0; }, function(x) { return (x & 1) === 0; });
 
+    equal(orPositiveEven(2), true, 'should recognize that element satisfies a disjunction');
+    equal(orPositiveEven(-1), false, 'should recognize that element does not satisfy a disjunction');
     equal(orPositiveEven([-1,2,3,4,5,6]), true, 'should recognize when all elements satisfy a disjunction');
     equal(orPositiveEven([-1,-3]), false, 'should recognize when an element fails to satisfy a disjunction');
   });

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -32,7 +32,9 @@
   var createPredicateApplicator = function (funcToInvoke /*, preds */) {
     var preds = _(arguments).tail();
 
-    return function (array) {
+    return function (objToCheck) {
+      var array = _(objToCheck).cat();
+
       return _[funcToInvoke](array, function (e) {
         return _[funcToInvoke](preds, function (p) {
           return p(e);
@@ -42,6 +44,7 @@
   };
 
   // n.b. depends on underscore.function.arity.js
+  // n.b. depends on underscore.array.builders.js
     
   // Takes a target function and a mapping function. Returns a function
   // that applies the mapper to its arguments before evaluating the body.

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -77,12 +77,12 @@
     // Composes a bunch of predicates into a single predicate that
     // checks all elements of an array for conformance to all of the
     // original predicates.
-    conjoin: _(createPredicateApplicator).partial('every'),
+    conjoin: _.partial(createPredicateApplicator, ('every')),
 
     // Composes a bunch of predicates into a single predicate that
     // checks all elements of an array for conformance to any of the
     // original predicates.
-    disjoin: _(createPredicateApplicator).partial('some'),
+    disjoin: _.partial(createPredicateApplicator, 'some'),
 
     // Takes a predicate-like and returns a comparator (-1,0,1).
     comparator: function(fun) {

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -29,6 +29,18 @@
     };
   };
   
+  var createPredicateApplicator = function (funcToInvoke /*, preds */) {
+    var preds = _(arguments).tail();
+
+    return function (array) {
+      return _[funcToInvoke](array, function (e) {
+        return _[funcToInvoke](preds, function (p) {
+          return p(e);
+        });
+      });
+    };
+  };
+
   // n.b. depends on underscore.function.arity.js
     
   // Takes a target function and a mapping function. Returns a function
@@ -62,32 +74,12 @@
     // Composes a bunch of predicates into a single predicate that
     // checks all elements of an array for conformance to all of the
     // original predicates.
-    conjoin: function(/* preds */) {
-      var preds = arguments;
-
-      return function(array) {
-        return _.every(array, function(e) {
-          return _.every(preds, function(p) {
-            return p(e);
-          });
-        });
-      };
-    },
+    conjoin: _(createPredicateApplicator).partial('every'),
 
     // Composes a bunch of predicates into a single predicate that
     // checks all elements of an array for conformance to any of the
     // original predicates.
-    disjoin: function(/* preds */) {
-      var preds = arguments;
-
-      return function(array) {
-        return _.some(array, function(e) {
-          return _.some(preds, function(p) {
-            return p(e);
-          });
-        });
-      };
-    },
+    disjoin: _(createPredicateApplicator).partial('some'),
 
     // Takes a predicate-like and returns a comparator (-1,0,1).
     comparator: function(fun) {


### PR DESCRIPTION
The `conjoin` and `disjoin` methods create a function that applies multiple predicates to an array.  This pull request is to allow the created function to also work on single objects (not just arrays).

Also refactored the `conjoin` and `disjoin` methods into `createPredicateApplicator`.

Note: this introduces a dependency on `underscore.array.builders.js`.  I'm assuming that this is OK as there was already a dependency on `underscore.function.arity.js`, let me know if this is not the case.