### PR TITLE
Adding _.combine

### DIFF
--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -204,6 +204,8 @@ $(document).ready(function() {
     var arr1 = [1,2], arr2 = [3,4,5], arr3 = [6,7],
         expected = [[1,3,6],[1,3,7],[1,4,6],[1,4,7],[1,5,6],[1,5,7],[2,3,6],[2,3,7],[2,4,6],[2,4,7],[2,5,6],[2,5,7]];
     deepEqual(_.combinations(arr1,arr2,arr3),expected,'array with all possible combinations is returned');
+
+    deepEqual(_.combinations(["a",["b"]],[[1]]),[["a",[1]],[["b"],[1]]],'initial arrays can contain array elements which are then preserved');
   });
 
 });

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -198,7 +198,7 @@
       return _.reduce(slice.call(arguments, 1),function(ret,newarr){
         return _.reduce(ret,function(memo,oldi){
           return memo.concat(_.map(newarr,function(newi){
-            return oldi.concat(newi);
+            return oldi.concat([newi]);
           }));
         },[]);
       },_.map(arguments[0],function(i){return [i];}));


### PR DESCRIPTION
This pull request implements a feature I've been missing; it returns an array of all possible combinations using one element each from the given arrays.

Each element in the return array with therefore contain as many elements as you fed `combine`, and the number of elements in the return array equals the product of the lengths of the given arrays.

Here's an example:

```
_.combine([1,2,3],["a","b"],[”foo","bar","baz"]);
// => [ [1,"a","foo"],[1,"a","bar"],[1,"a","baz"],[1,"b","foo"],[1,"b","bar"],[1,"b","baz"],[2,"a","foo"],[2,"a","bar"],[2,"a","baz"],[2,"b","foo"],[2,"b","bar"],[2,"b","baz"]]
```

This was deemed [not quite useful enough](https://github.com/jashkenas/underscore/pull/1788) for Underscore proper, but might qualify for _.contrib? I use it somewhat often, and as doing it "manually" is messy and verbose, a helper for this functionality really cleans up the code. 
