### PR TITLE
Load underscore and underscore.contrib on docs page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2025,6 +2025,9 @@ isEven(99999);
 <li>Switch <code>always</code> to an alias of Underscore&#39;s <code>constant</code>. - <a href="https://github.com/documentcloud/underscore-contrib/issues/132">#132</a></li>
 <li>The combinators sub-library now supports method combinators - <a href="https://github.com/documentcloud/underscore-contrib/issues/14">#14</a></li>
 </ul>
+  
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore-contrib/0.3.0/underscore-contrib.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
One of the great things about the Underscore docs is you can play around with the functions right from the docs page. Would be great to have underscore.contrib loaded and unminified on the docs page too.
