### PR TITLE
Change underscore import/export boiler plate

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,12 @@
+{
+	"globals": {
+		"_": true
+	},
+	"es3": true,
+    "indent": 2,
+    "camelcase": true,
+    "eqnull": true,
+    "forin": true,
+    "newcap": true,
+    "-W058": false
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,13 +44,7 @@ module.exports = function(grunt) {
         "test/*.js"
       ],
       options: {
-        es3: true,       // Enforce ES3 compatibility
-        indent: 2,       // Indent by 2 spaces
-        camelcase: true, // All vars must be camelCase or UPPER_WITH_UNDERSCORES
-        eqnull: true,    // Allow 'x == null' convention
-        forin: true,     // Require `for x in y` to filter with `hasOwnProperty`
-        newcap: true,    // Require constructor names to be capitalized
-        "-W058": false   // Allow 'new Constructor' without parens
+        jshintrc: true
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.11",
     "grunt-contrib-concat": "0.3.0",
-    "grunt-contrib-uglify": "0.2.0",
+    "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-qunit": "~0.2.2",
+    "grunt-contrib-uglify": "0.2.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-jshint": "~0.6.4",
     "grunt-docco": "~0.3.0",
-    "grunt-tocdoc": "0.1.1",
-    "grunt-cli": "~0.1.11"
+    "grunt-tocdoc": "0.1.1"
   },
   "repository": {
     "type": "git",

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -198,4 +200,4 @@
 
   });
 
-})(this);
+}).call(this);

--- a/underscore.array.selectors.js
+++ b/underscore.array.selectors.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -137,4 +139,4 @@
     }
   });
 
-})(this);
+}).call(this);

--- a/underscore.collections.walk.js
+++ b/underscore.collections.walk.js
@@ -2,13 +2,15 @@
 // (c) 2013 Patrick Dubroy
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -193,4 +195,4 @@
   // Use `_.walk` as a namespace to hold versions of the walk functions which
   // use the default traversal strategy.
   _.extend(_.walk, _.walk());
-})(this);
+}).call(this);

--- a/underscore.function.arity.js
+++ b/underscore.function.arity.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -209,4 +211,4 @@
     };
   })();
 
-})(this);
+}).call(this);

--- a/underscore.function.combinators.js
+++ b/underscore.function.combinators.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -263,4 +265,4 @@
     return _.bind(fn, obj);
   };
 
-})(this);
+}).call(this);

--- a/underscore.function.dispatch.js
+++ b/underscore.function.dispatch.js
@@ -2,13 +2,15 @@
 // (c) 2013 Justin Ridgewell
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -30,4 +32,4 @@
     }
   });
 
-})(this);
+}).call(this);

--- a/underscore.function.iterators.js
+++ b/underscore.function.iterators.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus and DocumentCloud Inc.
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root, undefined) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -340,4 +342,4 @@
     cycle: cycle
   };
 
-})(this, void 0);
+}).call(this, void 0);

--- a/underscore.function.predicates.js
+++ b/underscore.function.predicates.js
@@ -2,111 +2,106 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+// Establish the root object, `window` in the browser, or `require` it on the server.
+if (typeof exports === 'object') {
+  _ = module.exports = require('underscore');
+}
 
-  // Baseline setup
-  // --------------
-
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
-
-  // Helpers
-  // -------
+// Helpers
+// -------
 
 
-  // Mixing in the predicate functions
-  // ---------------------------------
+// Mixing in the predicate functions
+// ---------------------------------
 
-  _.mixin({
-    // A wrapper around instanceof
-    isInstanceOf: function(x, t) { return (x instanceof t); },
+_.mixin({
+  // A wrapper around instanceof
+  isInstanceOf: function(x, t) { return (x instanceof t); },
 
-    // An associative object is one where its elements are
-    // accessed via a key or index. (i.e. array and object)
-    isAssociative: function(x) { return _.isArray(x) || _.isObject(x) || _.isArguments(x); },
+  // An associative object is one where its elements are
+  // accessed via a key or index. (i.e. array and object)
+  isAssociative: function(x) { return _.isArray(x) || _.isObject(x) || _.isArguments(x); },
 
-    // An indexed object is anything that allows numerical index for
-    // accessing its elements (e.g. arrays and strings). NOTE: Underscore
-    // does not support cross-browser consistent use of strings as array-like
-    // objects, so be wary in IE 8 when using  String objects and IE<8.
-    // on string literals & objects.
-    isIndexed: function(x) { return _.isArray(x) || _.isString(x) || _.isArguments(x); },
+  // An indexed object is anything that allows numerical index for
+  // accessing its elements (e.g. arrays and strings). NOTE: Underscore
+  // does not support cross-browser consistent use of strings as array-like
+  // objects, so be wary in IE 8 when using  String objects and IE<8.
+  // on string literals & objects.
+  isIndexed: function(x) { return _.isArray(x) || _.isString(x) || _.isArguments(x); },
 
-    // A seq is something considered a sequential composite type (i.e. arrays and `arguments`).
-    isSequential: function(x) { return (_.isArray(x)) || (_.isArguments(x)); },
+  // A seq is something considered a sequential composite type (i.e. arrays and `arguments`).
+  isSequential: function(x) { return (_.isArray(x)) || (_.isArguments(x)); },
 
-    // Check if an object is an object literal, since _.isObject(function() {}) === _.isObject([]) === true
-    isPlainObject: function(x) { return _.isObject(x) && x.constructor === root.Object; },
+  // Check if an object is an object literal, since _.isObject(function() {}) === _.isObject([]) === true
+  isPlainObject: function(x) { return _.isObject(x) && x.constructor === Object; },
 
-    // These do what you think that they do
-    isZero: function(x) { return 0 === x; },
-    isEven: function(x) { return _.isFinite(x) && (x & 1) === 0; },
-    isOdd: function(x) { return _.isFinite(x) && !_.isEven(x); },
-    isPositive: function(x) { return x > 0; },
-    isNegative: function(x) { return x < 0; },
-    isValidDate: function(x) { return _.isDate(x) && !_.isNaN(x.getTime()); },
+  // These do what you think that they do
+  isZero: function(x) { return 0 === x; },
+  isEven: function(x) { return _.isFinite(x) && (x & 1) === 0; },
+  isOdd: function(x) { return _.isFinite(x) && !_.isEven(x); },
+  isPositive: function(x) { return x > 0; },
+  isNegative: function(x) { return x < 0; },
+  isValidDate: function(x) { return _.isDate(x) && !_.isNaN(x.getTime()); },
 
-    // A numeric is a variable that contains a numeric value, regardless its type
-    // It can be a String containing a numeric value, exponential notation, or a Number object
-    // See here for more discussion: http://stackoverflow.com/questions/18082/validate-numbers-in-javascript-isnumeric/1830844#1830844
-    isNumeric: function(n) {
-      return !isNaN(parseFloat(n)) && isFinite(n);
-    },
+  // A numeric is a variable that contains a numeric value, regardless its type
+  // It can be a String containing a numeric value, exponential notation, or a Number object
+  // See here for more discussion: http://stackoverflow.com/questions/18082/validate-numbers-in-javascript-isnumeric/1830844#1830844
+  isNumeric: function(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+  },
 
-    // An integer contains an optional minus sign to begin and only the digits 0-9
-    // Objects that can be parsed that way are also considered ints, e.g. "123"
-    // Floats that are mathematically equal to integers are considered integers, e.g. 1.0
-    // See here for more discussion: http://stackoverflow.com/questions/1019515/javascript-test-for-an-integer
-    isInteger: function(i) {
-      return _.isNumeric(i) && i % 1 === 0;
-    },
+  // An integer contains an optional minus sign to begin and only the digits 0-9
+  // Objects that can be parsed that way are also considered ints, e.g. "123"
+  // Floats that are mathematically equal to integers are considered integers, e.g. 1.0
+  // See here for more discussion: http://stackoverflow.com/questions/1019515/javascript-test-for-an-integer
+  isInteger: function(i) {
+    return _.isNumeric(i) && i % 1 === 0;
+  },
 
-    // A float is a numbr that is not an integer.
-    isFloat: function(n) {
-      return _.isNumeric(n) && !_.isInteger(n);
-    },
+  // A float is a numbr that is not an integer.
+  isFloat: function(n) {
+    return _.isNumeric(n) && !_.isInteger(n);
+  },
 
-    // checks if a string is a valid JSON
-    isJSON: function(str) {
-      try {
-        JSON.parse(str);
-      } catch (e) {
+  // checks if a string is a valid JSON
+  isJSON: function(str) {
+    try {
+      JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  },
+
+  // Returns true if its arguments are monotonically
+  // increaing values; false otherwise.
+  isIncreasing: function() {
+    var count = _.size(arguments);
+    if (count === 1) return true;
+    if (count === 2) return arguments[0] < arguments[1];
+
+    for (var i = 1; i < count; i++) {
+      if (arguments[i-1] >= arguments[i]) {
         return false;
       }
-      return true;
-    },
-
-    // Returns true if its arguments are monotonically
-    // increaing values; false otherwise.
-    isIncreasing: function() {
-      var count = _.size(arguments);
-      if (count === 1) return true;
-      if (count === 2) return arguments[0] < arguments[1];
-
-      for (var i = 1; i < count; i++) {
-        if (arguments[i-1] >= arguments[i]) {
-          return false;
-        }
-      }
-
-      return true;
-    },
-
-    // Returns true if its arguments are monotonically
-    // decreaing values; false otherwise.
-    isDecreasing: function() {
-      var count = _.size(arguments);
-      if (count === 1) return true;
-      if (count === 2) return arguments[0] > arguments[1];
-
-      for (var i = 1; i < count; i++) {
-        if (arguments[i-1] <= arguments[i]) {
-          return false;
-        }
-      }
-
-      return true;
     }
-  });
 
-})(this);
+    return true;
+  },
+
+  // Returns true if its arguments are monotonically
+  // decreaing values; false otherwise.
+  isDecreasing: function() {
+    var count = _.size(arguments);
+    if (count === 1) return true;
+    if (count === 2) return arguments[0] > arguments[1];
+
+    for (var i = 1; i < count; i++) {
+      if (arguments[i-1] <= arguments[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+});

--- a/underscore.object.builders.js
+++ b/underscore.object.builders.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -117,4 +119,4 @@
     frequencies: curry2(_.countBy)(_.identity)
   });
 
-})(this);
+}).call(this);

--- a/underscore.object.selectors.js
+++ b/underscore.object.selectors.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -123,4 +125,4 @@
 
   });
 
-})(this);
+}).call(this);

--- a/underscore.util.existential.js
+++ b/underscore.util.existential.js
@@ -2,31 +2,22 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
-
-  // Baseline setup
-  // --------------
-
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
-
-  // Helpers
-  // -------
-
+// Establish the root object, `window` in the browser, or `require` it on the server.
+if (typeof exports === 'object') {
+  _ = module.exports = require('underscore');
+}
   
-  // Mixing in the truthiness
-  // ------------------------
+// Mixing in the truthiness
+// ------------------------
 
-  _.mixin({
-    exists: function(x) { return x != null; },
-    truthy: function(x) { return (x !== false) && _.exists(x); },
-    falsey: function(x) { return !_.truthy(x); },
-    not:    function(b) { return !b; },
-    firstExisting: function() {
-      for (var i = 0; i < arguments.length; i++) {
-        if (arguments[i] != null) return arguments[i];
-      }
+_.mixin({
+  exists: function(x) { return x != null; },
+  truthy: function(x) { return (x !== false) && _.exists(x); },
+  falsey: function(x) { return !_.truthy(x); },
+  not:    function(b) { return !b; },
+  firstExisting: function() {
+    for (var i = 0; i < arguments.length; i++) {
+      if (arguments[i] != null) return arguments[i];
     }
-  });
-
-})(this);
+  }
+});

--- a/underscore.util.operators.js
+++ b/underscore.util.operators.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Setup for variadic operators
   // ----------------------------
@@ -175,4 +177,4 @@
     bitwiseRight: variadicMath(bitwiseRight),
     bitwiseZ: variadicMath(bitwiseZ)
   });
-})(this);
+}).call(this);

--- a/underscore.util.strings.js
+++ b/underscore.util.strings.js
@@ -2,13 +2,15 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+(function() {
 
   // Baseline setup
   // --------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+  // Establish the root object, `window` in the browser, or `require` it on the server.
+  if (typeof exports === 'object') {
+    _ = module.exports = require('underscore');
+  }
 
   // Helpers
   // -------
@@ -126,4 +128,4 @@
     }
 
   });
-})(this);
+}).call(this);

--- a/underscore.util.trampolines.js
+++ b/underscore.util.trampolines.js
@@ -2,38 +2,29 @@
 // (c) 2013 Michael Fogus, DocumentCloud and Investigative Reporters & Editors
 // Underscore-contrib may be freely distributed under the MIT license.
 
-(function(root) {
+// Establish the root object, `window` in the browser, or `require` it on the server.
+if (typeof exports === 'object') {
+  _ = module.exports = require('underscore');
+}
 
-  // Baseline setup
-  // --------------
+// Mixing in the truthiness
+// ------------------------
 
-  // Establish the root object, `window` in the browser, or `global` on the server.
-  var _ = root._ || require('underscore');
+_.mixin({
+  done: function(value) {
+    var ret = _(value);
+    ret.stopTrampoline = true;
+    return ret;
+  },
 
-  // Helpers
-  // -------
+  trampoline: function(fun /*, args */) {
+    var result = fun.apply(fun, _.rest(arguments));
 
-  
-  // Mixing in the truthiness
-  // ------------------------
-
-  _.mixin({
-    done: function(value) {
-      var ret = _(value);
-      ret.stopTrampoline = true;
-      return ret;
-    },
-
-    trampoline: function(fun /*, args */) {
-      var result = fun.apply(fun, _.rest(arguments));
-
-      while (_.isFunction(result)) {
-        result = result();
-        if ((result instanceof _) && (result.stopTrampoline)) break;
-      }
-
-      return result.value();
+    while (_.isFunction(result)) {
+      result = result();
+      if ((result instanceof _) && (result.stopTrampoline)) break;
     }
-  });
 
-})(this);
+    return result.value();
+  }
+});


### PR DESCRIPTION
Fixes #186

Lets you do

``` js
var _ = require("underscore-contrib/underscore.object.selectors");
```

PS I would also like to remove the `underscore.*` prefixes
