### PR TITLE
Insert function for arrays

### DIFF
--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -209,6 +209,9 @@ $(document).ready(function() {
   });
 
   test('insert', function(){
+    var throwingFn = function() { _.insert({}, 0, 1); };
+    throws(throwingFn, TypeError, 'throws a TypeError when passing an object literal');
+    
     deepEqual(_.insert([], 0, 1), [1],'inserts item in empty array');
     deepEqual(_.insert([2], 0, 1), [1,2],'inserst item at the corret index');
     deepEqual(_.insert([1,2], 2, 3), [1,2,3],'inserts item at the end of array if exceeding index');

--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -208,4 +208,9 @@ $(document).ready(function() {
     deepEqual(_.combinations(["a",["b"]],[[1]]),[["a",[1]],[["b"],[1]]],'initial arrays can contain array elements which are then preserved');
   });
 
+  test('insert', function(){
+    deepEqual(_.insert([], 0, 1), [1],'empty array will will insert item');
+    deepEqual(_.insert([1,3], 1, 2), [1,2,3],'array will insert item');
+    deepEqual(_.insert([1,3], 2, 2), [1,3,2],'exceeding index will insert item at the end');
+  });
 });

--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -209,8 +209,9 @@ $(document).ready(function() {
   });
 
   test('insert', function(){
-    deepEqual(_.insert([], 0, 1), [1],'empty array will will insert item');
-    deepEqual(_.insert([1,3], 1, 2), [1,2,3],'array will insert item');
-    deepEqual(_.insert([1,3], 2, 2), [1,3,2],'exceeding index will insert item at the end');
+    deepEqual(_.insert([], 0, 1), [1],'inserts item in empty array');
+    deepEqual(_.insert([2], 0, 1), [1,2],'inserst item at the corret index');
+    deepEqual(_.insert([1,2], 2, 3), [1,2,3],'inserts item at the end of array if exceeding index');
+    deepEqual(_.insert([1,3], -1, 2), [1,2,3],'inserst item at the correct index if negative index');
   });
 });

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -196,6 +196,13 @@
           }));
         },[]);
       },_.map(arguments[0],function(i){return [i];}));
+    },
+    
+    // Inserts an item in an array at the specific index
+    insert: function(array, index, item){
+      var copy = array.slice(0);
+      copy.splice(index, 0, item);
+      return copy;
     }
 
   });

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -17,6 +17,7 @@
   
   // Create quick reference variables for speed access to core prototypes.
   var slice   = Array.prototype.slice;
+  var splice  = Array.prototype.splice;
 
   var existy = function(x) { return x != null; };
 
@@ -198,11 +199,11 @@
       },_.map(arguments[0],function(i){return [i];}));
     },
     
-    // Inserts an item in an array at the specific index
+    // Inserts an item in an array at the specific index mutating the original
+    // array and returning it.
     insert: function(array, index, item){
-      var copy = array.slice(0);
-      copy.splice(index, 0, item);
-      return copy;
+      splice.call(array, index, 0, item);
+      return array;
     }
 
   });

--- a/underscore.array.builders.js
+++ b/underscore.array.builders.js
@@ -202,6 +202,7 @@
     // Inserts an item in an array at the specific index mutating the original
     // array and returning it.
     insert: function(array, index, item){
+      if (!_.isArray(array)) throw new TypeError('Expected an array as the first argument');
       splice.call(array, index, 0, item);
       return array;
     }


### PR DESCRIPTION
I thought an 'insert item at' function for arrays would be nice to have, avoiding the use of [splice](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/splice "Splice") where 0 needs to be passed as the 2nd 'deleteCount' parameter.

It works the same way the _.extend function does, where the first parameter gets modified and the result is also returned.
