### PR TITLE
Update underscore dependency to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "main": "index.js",
   "dependencies": {
-    "underscore": "1.7.0"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
The current underscore dependency is over a year old,
this ensures that underscore-contrib is up-to-date.

I have verified that the test and dist tasks still
pass and run to completion.
