### PR TITLE
Make grunt working again.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,8 +88,9 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask("test", ["jshint", "qunit:main"]);
-  grunt.registerTask("dist", ["concat", "uglify"]);
+  grunt.registerTask('test', ['jshint', 'qunit:main']);
+  grunt.registerTask('dist', ['concat', 'uglify']);
   grunt.registerTask('default', ['test']);
   grunt.registerTask('dist', ['test', 'concat', 'qunit:concat', 'uglify', 'qunit:min']);
+  grunt.registerTask('doc', ['test', 'tocdoc']);
 };

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
     "underscore": "1.7.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.11",
+    "grunt": "^1.2.0",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-concat": "0.3.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-qunit": "~0.2.2",
-    "grunt-contrib-uglify": "0.2.0",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-contrib-qunit": "^4.0.0",
+    "grunt-contrib-uglify": "^4.0.1",
+    "grunt-contrib-watch": "^1.1.0",
     "grunt-docco": "~0.3.0",
-    "grunt-tocdoc": "0.1.1"
+    "grunt-tocdoc": "0.1.1",
+    "qunit": "^2.10.0"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,10 @@
     "url": "http://www.fogus.me"
   },
   "scripts": {
-    "test": "node ./node_modules/grunt-cli/bin/grunt test"
+    "test": "node ./node_modules/grunt-cli/bin/grunt test",
+    "dist": "node ./node_modules/grunt-cli/bin/grunt dist",
+    "tocdoc": "node ./node_modules/grunt-cli/bin/grunt tocdoc",
+    "docco": "node ./node_modules/grunt-cli/bin/grunt docco"
   },
   "homepage": "https://github.com/documentcloud/underscore-contrib"
 }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "url": "http://www.fogus.me"
   },
   "scripts": {
-    "test": "node ./node_modules/grunt-cli/bin/grunt test",
-    "dist": "node ./node_modules/grunt-cli/bin/grunt dist",
-    "tocdoc": "node ./node_modules/grunt-cli/bin/grunt tocdoc",
-    "docco": "node ./node_modules/grunt-cli/bin/grunt docco"
+    "test": "grunt test",
+    "dist": "grunt dist",
+    "tocdoc": "grunt tocdoc",
+    "docco": "grunt docco"
   },
   "homepage": "https://github.com/documentcloud/underscore-contrib"
 }


### PR DESCRIPTION
This solves first step of mentioned maintenance -1. Fix things so that development is smooth again. Upgraded grunt and its dev-dependencies. Note that tests are executed via puppeteer now which uses Chromium. Puppeteer freezes on old minified/uglyfied files, but works well on firefox manully. When running `npm dist` everything works smooth then. I am not sure if commit products of `npm dist` for now - possible lost of backward compatibility for user of latest version.