### PR TITLE
_.toQuery fix

### DIFF
--- a/test/util.strings.js
+++ b/test/util.strings.js
@@ -43,6 +43,8 @@ $(document).ready(function() {
     var obj = {'foo&bar': 'baz', 'test': 'total success', 'nested': {'works': 'too'}, 'isn\'t': ['that', 'cool?']};
     assert.equal(_.toQuery(obj), 'foo%26bar=baz&test=total%20success&nested%5Bworks%5D=too&isn\'t%5B%5D=that&isn\'t%5B%5D=cool%3F', 'can convert a hash to a query string');
     assert.equal(_.toQuery(obj), jQuery.param(obj), 'query serialization matchs jQuery.param()');
+    assert.equal(_.toQuery({a: []}), '', 'empty array params produce the empty string');
+    assert.equal(_.toQuery({a: [], b: []}), '', 'multiple empty array params do not lead to spurious ampersands');
   });
 
   QUnit.test('strContains', function(assert) {

--- a/test/util.strings.js
+++ b/test/util.strings.js
@@ -45,6 +45,7 @@ $(document).ready(function() {
     assert.equal(_.toQuery(obj), jQuery.param(obj), 'query serialization matchs jQuery.param()');
     assert.equal(_.toQuery({a: []}), '', 'empty array params produce the empty string');
     assert.equal(_.toQuery({a: [], b: []}), '', 'multiple empty array params do not lead to spurious ampersands');
+    assert.equal(_.toQuery({a: null, b: undefined}), 'a=null&b=undefined', 'respects null and undefined');
   });
 
   QUnit.test('strContains', function(assert) {

--- a/underscore.util.strings.js
+++ b/underscore.util.strings.js
@@ -29,9 +29,9 @@
   var buildParams = function(prefix, val, top) {
     if (_.isUndefined(top)) top = true;
     if (_.isArray(val)) {
-      return _.map(val, function(value, key) {
+      return _.compact(_.map(val, function(value, key) {
         return buildParams(top ? key : prefix + '[]', value, false);
-      }).join('&');
+      })).join('&');
     } else if (_.isObject(val)) {
       return _.compact(_.map(val, function(value, key) {
         return buildParams(top ? key : prefix + '[' + key + ']', value, false);

--- a/underscore.util.strings.js
+++ b/underscore.util.strings.js
@@ -33,9 +33,9 @@
         return buildParams(top ? key : prefix + '[]', value, false);
       }).join('&');
     } else if (_.isObject(val)) {
-      return _.map(val, function(value, key) {
+      return _.compact(_.map(val, function(value, key) {
         return buildParams(top ? key : prefix + '[' + key + ']', value, false);
-      }).join('&');
+      })).join('&');
     } else {
       return urlEncode(prefix) + '=' + urlEncode(val);
     }


### PR DESCRIPTION
This branch adresses #217. For a query payload like `{a: [], b: []}`, I had two options to choose from: `'a=&b='` or just the empty string `''`. Since `{a: []}` already encoded to the empty string, the empty string also seemed to be the right generalization for multiple empty arrays. This choice is further justified by two other facts: `_.fromQuery('a=')` returns `{a: ''}` rather than `{a: []}`, and jQuery encodes empty array parameters as empty strings, too.

@mafiosso @sktguha @yashshah1 @carpben if one of you could review this, that would be great.