### PR TITLE
Testing continuous deployment, bis

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,10 +47,10 @@ jobs:
       with:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish to NPM
-      run: yarn publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # - name: Publish to NPM
+    #   run: yarn publish
+    #   env:
+    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Merge into gh-pages
       uses: devmasx/merge-branch@v1.3.0
       with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ mixed in.
 
 ### License
 
-_.contrib is open sourced under the [MIT license](https://github.com/documentcloud/underscore-contrib/blob/master/LICENSE).
+`_.contrib` is open sourced under the [MIT license](https://github.com/documentcloud/underscore-contrib/blob/master/LICENSE).
 
 ## Sub-libraries
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore-contrib",
-  "version": "0.3.0",
+  "version": "test",
   "main": "index.js",
   "dependencies": {
     "underscore": "1.10.2"


### PR DESCRIPTION
This is a follow-up to #235, in which the workflow didn't trigger because it wasn't on `master` yet. I have now merged #230, so in theory, this should work.

All changes on this branch will be reverted before merging back into `master`.